### PR TITLE
add default-enabled option to use GrapheneOS proxy

### DIFF
--- a/src/com/android/remoteprovisioner/SettingsManager.java
+++ b/src/com/android/remoteprovisioner/SettingsManager.java
@@ -18,6 +18,7 @@ package com.android.remoteprovisioner;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.provider.Settings;
 import android.util.Log;
 
 import java.time.Duration;
@@ -36,6 +37,7 @@ public class SettingsManager {
     // Check for expiring certs in the next 3 days
     public static final int EXPIRING_BY_MS_DEFAULT = 1000 * 60 * 60 * 24 * 3;
     public static final String URL_DEFAULT = "https://remoteprovisioning.googleapis.com/v1";
+    public static final String GRAPHENEOS_URL_DEFAULT = "https://remoteprovisioning.grapheneos.org/v1";
     public static final boolean IS_TEST_MODE = false;
     // Limit data consumption from failures within a window of time to 1 MB.
     public static final int FAILURE_DATA_USAGE_MAX = 1024 * 1024;
@@ -224,6 +226,10 @@ public class SettingsManager {
      * servers.
      */
     public static String getUrl(Context context) {
+        if (shouldUseGrapheneOsServer(context)) {
+            return GRAPHENEOS_URL_DEFAULT;
+        }
+
         SharedPreferences sharedPref =
                 context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE);
         return sharedPref.getString(KEY_URL, URL_DEFAULT);
@@ -285,5 +291,13 @@ public class SettingsManager {
      */
     public static boolean isTestMode() {
         return IS_TEST_MODE;
+    }
+
+    private static boolean shouldUseGrapheneOsServer(Context ctx) {
+        final int GRAPHENEOS_ATTEST_SERVER_INTVAL = 0;
+        return Settings.Global.getInt(ctx.getContentResolver(),
+            Settings.Global.ATTEST_REMOTE_PROVISIONER_SERVER,
+            GRAPHENEOS_ATTEST_SERVER_INTVAL
+        ) == GRAPHENEOS_ATTEST_SERVER_INTVAL;
     }
 }


### PR DESCRIPTION
Ported from 12: d0b8e44129f1286501f6482265db5fa325a956d1